### PR TITLE
Document temperature sensor for chunmi.cooker.normal2

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ switch:
                 piid: 1
                 value: false
 
+
+```
+
+An example for using the raw sensor to create a rice-cooker temperature sensor based on the raw data. Tested on an `chunmi.cooker.normal2`. This sensor always provides the current temperature unlike the the official sensor that only works during the rice program.
+
+```yaml
+sensor:
+  - platform: xiaomi_miio_raw
+    name: cooker
+    host: 192.168.0.122
+    token: 
+    sensor_property: 'unnamed11'
+    default_properties_getter: 'get_prop'
+    default_properties:
+    - 'all'
+
+template:
+  - sensor:
+      - name: "Cooker Temperature"
+        unit_of_measurement: "°C"
+        state: "{{ states.sensor.cooker_2.state[28:-2] |int(base=16) }}"
+        state_class: measurement
+        device_class: temperature
+        availability: "{{ states.sensor.cooker_2.state != 'unavailable' }}"
 ```
 
 Configuration variables (sensor platform):


### PR DESCRIPTION
Thanks for publishing the raw sensor it really helps with getting further down on the my cookers programs.

I didn't see that documented anywhere else yet so maybe here would be a good place to put it as an example.
property11 contains the cookers temperature in Celsius in the bytes 28+29. 

In the graph below we can see first the rice program with auto-keep-warm and then from 17:10 the steaming program.
Please let me know if you see a better place to document this.

![image](https://user-images.githubusercontent.com/6293002/143678542-0a908407-0dea-4e95-8261-ce497c143ff4.png)
