### PR TITLE
Keep all raw sensor entities in service registry

### DIFF
--- a/custom_components/xiaomi_miio_raw/sensor.py
+++ b/custom_components/xiaomi_miio_raw/sensor.py
@@ -106,7 +106,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     except DeviceException:
         raise PlatformNotReady
 
-    hass.data[DATA_KEY][host] = device
+    hass.data[DATA_KEY][device.unique_id] = device
     async_add_devices([device], update_before_add=True)
 
     async def async_service_handler(service):


### PR DESCRIPTION
Stores raw sensor entities by unique_id instead of host in hass.data.

This prevents multiple sensor platform entries for the same device host from overwriting each other, allowing platform services to target all configured raw sensor entities correctly.