### PR TITLE
Fix pre-commit violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GitHub watchers](https://img.shields.io/github/watchers/syssi/xiaomi_raw)
 [!["Buy Me A Coffee"](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg)](https://www.buymeacoffee.com/syssi)
 
-This is a custom component for home assistant to faciliate the reverse engeneering of Xiaomi MiIO devices.
+This is a custom component for home assistant to facilitate the reverse engineering of Xiaomi MiIO devices.
 
 Please follow the instructions on [Retrieving the Access Token](https://www.home-assistant.io/integrations/xiaomi_miio/#xiaomi-cloud-tokens-extractor) to get the API token to use in the configuration.yaml file.
 

--- a/custom_components/xiaomi_miio_raw/__init__.py
+++ b/custom_components/xiaomi_miio_raw/__init__.py
@@ -1,0 +1,1 @@
+"""Xiaomi Miio Raw custom component."""

--- a/custom_components/xiaomi_miio_raw/manifest.json
+++ b/custom_components/xiaomi_miio_raw/manifest.json
@@ -1,17 +1,12 @@
 {
   "domain": "xiaomi_miio_raw",
   "name": "Custom component for Home Assistant to faciliate the reverse engeneering of Xiaomi MiIO devices",
-  "codeowners": [
-    "@syssi"
-  ],
+  "codeowners": ["@syssi"],
   "config_flow": false,
   "dependencies": [],
   "documentation": "https://github.com/syssi/xiaomi_raw",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/syssi/xiaomi_raw/issues",
-  "requirements": [
-    "construct==2.10.68",
-    "python-miio>=0.5.12"
-  ],
+  "requirements": ["construct==2.10.68", "python-miio>=0.5.12"],
   "version": "2024.4.0.0"
 }

--- a/custom_components/xiaomi_miio_raw/sensor.py
+++ b/custom_components/xiaomi_miio_raw/sensor.py
@@ -1,15 +1,17 @@
-import asyncio
-import logging
-from ast import literal_eval
-from functools import partial
+"""Xiaomi Miio Raw sensor platform."""
 
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
+from ast import literal_eval
+import asyncio
+from functools import partial
+import logging
+
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from miio import Device, DeviceException
+import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -103,8 +105,8 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         )
 
         device = XiaomiMiioGenericDevice(miio_device, config, device_info)
-    except DeviceException:
-        raise PlatformNotReady
+    except DeviceException as err:
+        raise PlatformNotReady from err
 
     hass.data[DATA_KEY][host] = device
     async_add_devices([device], update_before_add=True)
@@ -135,8 +137,8 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         if update_tasks:
             await asyncio.wait(update_tasks)
 
-    for service in SERVICE_TO_METHOD:
-        schema = SERVICE_TO_METHOD[service].get("schema", SERVICE_SCHEMA)
+    for service, value in SERVICE_TO_METHOD.items():
+        schema = value.get("schema", SERVICE_SCHEMA)
         hass.services.async_register(
             DOMAIN, service, async_service_handler, schema=schema
         )
@@ -164,8 +166,8 @@ class XiaomiMiioGenericDevice(Entity):
             self._properties.append(self._sensor_property)
 
         self._model = device_info.model
-        self._unique_id = "{}-{}-{}".format(
-            device_info.model, device_info.mac_address, self._sensor_property
+        self._unique_id = (
+            f"{device_info.model}-{device_info.mac_address}-{self._sensor_property}"
         )
         self._icon = "mdi:flask-outline"
 
@@ -181,14 +183,15 @@ class XiaomiMiioGenericDevice(Entity):
         }
 
     def set_properties(self, properties):
+        """Parse and store the properties configuration."""
         if self._properties_getter != CMD_GET_PROPERTIES:
             self._properties = list(set(properties))
             return self._properties
         else:
             attrs = {}
-            for p in properties:
-                p = literal_eval(p)
-                attrs[p["siid"], p["piid"]] = p.pop("name", p["did"]), p
+            for prop_str in properties:
+                prop = literal_eval(prop_str)
+                attrs[prop["siid"], prop["piid"]] = prop.pop("name", prop["did"]), prop
             self._properties = attrs
             return list(i[0] for i in attrs.values())
 
@@ -295,7 +298,7 @@ class XiaomiMiioGenericDevice(Entity):
                 (attrs[i["siid"], i["piid"]][0], i.get("value")) for i in values
             )
         else:
-            state = dict(zip(attrs, values))
+            state = dict(zip(attrs, values, strict=False))
 
         _LOGGER.info("New state: %s", state)
 
@@ -342,7 +345,7 @@ class XiaomiMiioGenericDevice(Entity):
 
     async def async_command(self, method: str, params):
         """Send a raw command to the device."""
-        _LOGGER.info("Sending command: %s %s" % (method, params))
+        _LOGGER.info("Sending command: %s %s", method, params)
         await self._try_command(
             "Turning the miio device on failed.", self._device.send, method, params
         )

--- a/custom_components/xiaomi_miio_raw/switch.py
+++ b/custom_components/xiaomi_miio_raw/switch.py
@@ -1,13 +1,14 @@
-import asyncio
-import logging
-from functools import partial
+"""Xiaomi Miio Raw switch platform."""
 
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
+from functools import partial
+import logging
+
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.exceptions import PlatformNotReady
+import homeassistant.helpers.config_validation as cv
 from miio import Device, DeviceException
+import voluptuous as vol
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ ATTR_HARDWARE_VERSION = "hardware_version"
 
 SUCCESS = ["ok"]
 
+
 # pylint: disable=unused-argument
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the sensor from config."""
@@ -78,11 +80,12 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
         )
 
         device = XiaomiMiioGenericDevice(miio_device, config, device_info)
-    except DeviceException:
-        raise PlatformNotReady
+    except DeviceException as err:
+        raise PlatformNotReady from err
 
     hass.data[DATA_KEY][host] = device
     async_add_devices([device], update_before_add=True)
+
 
 class XiaomiMiioGenericDevice(SwitchEntity):
     """Representation of a Xiaomi Miio Generic Device."""
@@ -104,8 +107,8 @@ class XiaomiMiioGenericDevice(SwitchEntity):
         self._skip_update = False
 
         self._model = device_info.model
-        self._unique_id = "{}-{}-{}".format(
-            device_info.model, device_info.mac_address, self._state_property
+        self._unique_id = (
+            f"{device_info.model}-{device_info.mac_address}-{self._state_property}"
         )
         self._icon = "mdi:flask-outline"
 
@@ -156,7 +159,9 @@ class XiaomiMiioGenericDevice(SwitchEntity):
     async def _try_command(self, mask_error, func, *args, **kwargs):
         """Call a device command handling error messages."""
         try:
-            result = await self.hass.async_add_executor_job(partial(func, *args, **kwargs))
+            result = await self.hass.async_add_executor_job(
+                partial(func, *args, **kwargs)
+            )
             _LOGGER.info("Response received from miio device: %s", result)
             return result == SUCCESS
         except DeviceException as exc:


### PR DESCRIPTION
## Summary

Fixes all issues reported by `pre-commit run --all-files` against the modernized toolchain (ruff, codespell, prettier).

- Add module/package docstrings (`D100`, `D104`)
- Chain exceptions with `raise ... from err` (`B904`)
- Use `.items()` in dict iteration (`PLC0206`)
- Add docstring to `set_properties` (`D102`)
- Rename loop variable `p` → `prop` to avoid shadowing (`PLW2901`)
- Add `strict=False` to `zip()` (`B905`)
- Use logging `%`-args instead of `%`-string formatting (`UP031`)
- Fix typos in README: _faciliate_ → _facilitate_, _engeneering_ → _engineering_
- Apply `ruff-format` and `prettier` auto-fixes