### PR TITLE
Prevent zero max_properties values

### DIFF
--- a/custom_components/xiaomi_miio_raw/sensor.py
+++ b/custom_components/xiaomi_miio_raw/sensor.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             cv.ensure_list, [cv.string]
         ),
         vol.Optional(CONF_MAX_PROPERTIES, default=15): vol.All(
-            vol.Coerce(int), vol.Range(min=1)
+            vol.Coerce(int), vol.Range(min=1, max=16)
         ),
     }
 )

--- a/custom_components/xiaomi_miio_raw/sensor.py
+++ b/custom_components/xiaomi_miio_raw/sensor.py
@@ -37,7 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             cv.ensure_list, [cv.string]
         ),
         vol.Optional(CONF_MAX_PROPERTIES, default=15): vol.All(
-            vol.Coerce(int), vol.Range(min=1, max=16)
+            vol.Coerce(int), vol.Range(min=1)
         ),
     }
 )

--- a/custom_components/xiaomi_miio_raw/sensor.py
+++ b/custom_components/xiaomi_miio_raw/sensor.py
@@ -36,7 +36,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_DEFAULT_PROPERTIES, default=["power"]): vol.All(
             cv.ensure_list, [cv.string]
         ),
-        vol.Optional(CONF_MAX_PROPERTIES, default=15): cv.positive_int,
+        vol.Optional(CONF_MAX_PROPERTIES, default=15): vol.All(
+            vol.Coerce(int), vol.Range(min=1)
+        ),
     }
 )
 


### PR DESCRIPTION
Prevents `max_properties` from being configured as `0`.

Home Assistant's `cv.positive_int` allows zero, but this integration uses `max_properties` as the chunk size while fetching properties. A value of zero prevents the property list from being reduced and can make the update loop run forever.

This change validates `max_properties` with a minimum value of 1.

---
`max_properties` is used as the chunk size here:

```py
_props[: self._max_properties]
_props[:] = _props[self._max_properties :]
```

If the value is `0`, `_props` is never reduced and the update loop cannot finish. The upper bound of `16` matches the existing implementation that a single miIO request supports maximum 16 properties.